### PR TITLE
allow setting timezones other than UTC

### DIFF
--- a/deps/required-deps.txt
+++ b/deps/required-deps.txt
@@ -33,3 +33,4 @@ libwebpmux1
 software-properties-common
 fonts-powerline
 ghostscript
+tzdata


### PR DESCRIPTION
My server is set to localtime instead of UTC. I need the timezone data in the container in order to get duo to work.