### PR TITLE
Fix log growth of catalina.out

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ ARG RUNTIME_DEPENDENCIES=" \
     xfonts-terminus        \
     fonts-powerline        \
     tzdata                 \
-	logrotate              \
+    logrotate              \
     procps"
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,7 @@ ARG RUNTIME_DEPENDENCIES=" \
     xfonts-terminus        \
     fonts-powerline        \
     tzdata                 \
+	logrotate              \
     procps"
 
 

--- a/image-mariadb/etc/firstrun/mariadb.sh
+++ b/image-mariadb/etc/firstrun/mariadb.sh
@@ -97,8 +97,8 @@ else
     echo "Setting database file permissions"
     chown -R abc:abc /config/databases
     chmod -R 755 /config/databases
-	echo "Removing mysql-server logrotate directive"
-	rm /etc/logrotate.d/mysql-server
+    echo "Removing mysql-server logrotate directive"
+    rm /etc/logrotate.d/mysql-server
     sleep 3
     echo "Initialization complete."
   else

--- a/image-mariadb/etc/firstrun/mariadb.sh
+++ b/image-mariadb/etc/firstrun/mariadb.sh
@@ -97,6 +97,8 @@ else
     echo "Setting database file permissions"
     chown -R abc:abc /config/databases
     chmod -R 755 /config/databases
+	echo "Removing mysql-server logrotate directive"
+	rm /etc/logrotate.d/mysql-server
     sleep 3
     echo "Initialization complete."
   else


### PR DESCRIPTION
Catalina.out file grows forever, as logrotate was not included in the installed packages. Fixed

The default mysql-server logrotate config is not required in this configuration, removing to reduce errors.