### PR TITLE
mysql db userid modification

### DIFF
--- a/image-mariadb/etc/firstrun/mariadb.sh
+++ b/image-mariadb/etc/firstrun/mariadb.sh
@@ -8,7 +8,7 @@ MYSQL_DATABASE=/config/databases
 sed -i -e 's#\(datadir.*=\).*#\1 /config/databases#g' /etc/mysql/my.cnf
 sed -i -e 's#\(bind-address.*=\).*#\1 127.0.0.1#g' /etc/mysql/my.cnf
 sed -i -e '/log_warnings.*=.*/a log_error = /config/databases/mysql_safe.log' /etc/mysql/my.cnf
-sed -i -e 's/\(user.*=\).*/\1 nobody/g' /etc/mysql/my.cnf
+sed -i -e 's/\(user.*=\).*/\1 '"$PUID"'/g' /etc/mysql/my.cnf
 echo '[mysqld]' > /etc/mysql/conf.d/innodb_file_per_table.cnf
 echo 'innodb_file_per_table' >> /etc/mysql/conf.d/innodb_file_per_table.cnf
 mkdir -p /var/run/mysqld /var/log/mysql


### PR DESCRIPTION
nobody in docker container has id of 65534.  nobody in unraid 6.11.5 has id of 99.  ID mismatch between container and unraid caused db file creation permission issues for mysql inside of /mnt/user/appdata/ApacheGuacamole/databases/ dir.  Change mariadb.sh to create files as $PUID, resolves permissions issue and allows mysql db to be created properly