### PR TITLE
Upgrade to latest guacamole 1.5.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,8 @@ RUN apk add --no-cache ${RUNTIME_DEPENDENCIES}                                  
     xargs apk add --no-cache < ${PREFIX_DIR}/DEPENDENCIES                                                                                                                           && \
     adduser -h /config -s /bin/nologin -u 99 -D abc                                                                                                                                 && \
     adduser -h /opt/tomcat -s /bin/false -D tomcat                                                                                                                                  && \
-    TOMCAT_VERSION=$(wget -qO- https://tomcat.apache.org/download-10.cgi | grep "10\.1\.[0-9]\+</a>" | sed -e 's|.*>\(.*\)<.*|\1|g')                                                 && \
-    wget https://dlcdn.apache.org/tomcat/tomcat-10/v"$TOMCAT_VERSION"/bin/apache-tomcat-"$TOMCAT_VERSION".tar.gz                                                                     && \
+    TOMCAT_VERSION=$(wget -qO- https://tomcat.apache.org/download-90.cgi | grep "9\.0\.[0-9]\+</a>" | sed -e 's|.*>\(.*\)<.*|\1|g')                                                 && \
+    wget https://dlcdn.apache.org/tomcat/tomcat-9/v"$TOMCAT_VERSION"/bin/apache-tomcat-"$TOMCAT_VERSION".tar.gz                                                                     && \
     tar -xf apache-tomcat-"$TOMCAT_VERSION".tar.gz                                                                                                                                  && \
     mv apache-tomcat-"$TOMCAT_VERSION"/* /opt/tomcat                                                                                                                                && \
     rmdir apache-tomcat-"$TOMCAT_VERSION"                                                                                                                                           && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 ### Dockerfile for guacamole
 ### Includes the mysql authentication module preinstalled
 
-ARG GUAC_VER=1.5.4
+ARG GUAC_VER=1.5.5
+# alpine 3.19+ does not have libcrypto1.1 anymore
+# https://issues.apache.org/jira/browse/GUACAMOLE-1891
+# Full EOL date for Alpine 3.18 is 2025-05-09.
+ARG ALPINE_VER=3.18
 
 ########################
 ### Get Guacamole Server
@@ -17,7 +21,7 @@ FROM guacamole/guacamole:${GUAC_VER} AS client
 
 ###############################
 ### Build image without MariaDB
-FROM alpine:3.18 AS nomariadb
+FROM alpine:${ALPINE_VER} AS nomariadb
 ARG GUAC_VER
 LABEL version=$GUAC_VER
 
@@ -64,8 +68,8 @@ RUN apk add --no-cache ${RUNTIME_DEPENDENCIES}                                  
     xargs apk add --no-cache < ${PREFIX_DIR}/DEPENDENCIES                                                                                                                           && \
     adduser -h /config -s /bin/nologin -u 99 -D abc                                                                                                                                 && \
     adduser -h /opt/tomcat -s /bin/false -D tomcat                                                                                                                                  && \
-    TOMCAT_VERSION=$(wget -qO- https://tomcat.apache.org/download-80.cgi | grep "8\.5\.[0-9]\+</a>" | sed -e 's|.*>\(.*\)<.*|\1|g')                                                 && \
-    wget https://dlcdn.apache.org/tomcat/tomcat-8/v"$TOMCAT_VERSION"/bin/apache-tomcat-"$TOMCAT_VERSION".tar.gz                                                                     && \
+    TOMCAT_VERSION=$(wget -qO- https://tomcat.apache.org/download-10.cgi | grep "10\.1\.[0-9]\+</a>" | sed -e 's|.*>\(.*\)<.*|\1|g')                                                 && \
+    wget https://dlcdn.apache.org/tomcat/tomcat-10/v"$TOMCAT_VERSION"/bin/apache-tomcat-"$TOMCAT_VERSION".tar.gz                                                                     && \
     tar -xf apache-tomcat-"$TOMCAT_VERSION".tar.gz                                                                                                                                  && \
     mv apache-tomcat-"$TOMCAT_VERSION"/* /opt/tomcat                                                                                                                                && \
     rmdir apache-tomcat-"$TOMCAT_VERSION"                                                                                                                                           && \


### PR DESCRIPTION
I upgraded alpine to 3.18 because we cannot go up to 3.19 due to https://issues.apache.org/jira/browse/GUACAMOLE-1891.

Tomcat 8 went EOL and the downloads broke. I tried to go up to Tomcat 10 but there are too many changes so I upgraded to Tomcat 9.